### PR TITLE
Add vscode-dbt as extension dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,8 @@
 	},
 	"dependencies": {
 		"dbt-formatter": "^1.2.0"
-	}
+	},
+	"extensionDependencies": [
+		"bastienboutonnet.vscode-dbt"
+	]
 }


### PR DESCRIPTION
# Aim
Following your install recommendation I submitted #1 advising to add vscode-dbt as a dependency to your package and pasted a link. Then I thought I might as well do a PR and add it.

I didn't test the formatter after adding this though.